### PR TITLE
replaced plist_options with service.require_root

### DIFF
--- a/Formula/evcc.rb
+++ b/Formula/evcc.rb
@@ -44,7 +44,7 @@ class Evcc < Formula
     end
   end
 
-  plist_options startup: false
+  service.require_root startup: false
 
   def plist
     <<~EOS


### PR DESCRIPTION
I replaced `plist_options` with `service.require_root` to avoid the following deprecation warning:

`Warning: Calling plist_options is deprecated! Use service.require_root instead.
Please report this issue to the evcc-io/tap tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/evcc-io/homebrew-tap/Formula/evcc.rb:47`